### PR TITLE
Unscale points

### DIFF
--- a/blackbox.py
+++ b/blackbox.py
@@ -272,8 +272,8 @@ def getNextPoints(inpoints,N, fitkwargs = {}, ptkwargs = {},method='rbf',plot=Fa
 
 
     # Return the unScaled points (with dimensions)
-    # return(unScalePoints(box,newpoints))
-    return(newpoints)
+    return(unScalePoints(box,newpoints))
+    #return(newpoints)
 
 def getNewPointsBayes(inpoints,N):
 


### PR DESCRIPTION
I think the unscaling of points in the getNextPoints function was commented out accidentally. It seems to be returning the scaled version.